### PR TITLE
feat(edge-service): add BacnetConnectorProperties (no wiring yet)

### DIFF
--- a/apps/edge-service/src/main/java/org/metrolink/bas/edge/BacnetConnectorProperties.java
+++ b/apps/edge-service/src/main/java/org/metrolink/bas/edge/BacnetConnectorProperties.java
@@ -1,0 +1,30 @@
+package org.metrolink.bas.edge;
+
+import org.springframework.boot.context.properties.ConfigurationProperties;
+
+@ConfigurationProperties(prefix = "connectors.bacnet")
+public class BacnetConnectorProperties {
+
+    // Defaults you can override in application.yml
+    private int deviceInstance = 12345;
+    private int apduTimeoutMs = 3000;
+    private int covRenewSec = 120;
+    private double defaultCovIncrement = 0.1;
+    private boolean bbmdEnabled = false;
+
+    // getters/setters
+    public int getDeviceInstance() { return deviceInstance; }
+    public void setDeviceInstance(int deviceInstance) { this.deviceInstance = deviceInstance; }
+
+    public int getApduTimeoutMs() { return apduTimeoutMs; }
+    public void setApduTimeoutMs(int apduTimeoutMs) { this.apduTimeoutMs = apduTimeoutMs; }
+
+    public int getCovRenewSec() { return covRenewSec; }
+    public void setCovRenewSec(int covRenewSec) { this.covRenewSec = covRenewSec; }
+
+    public double getDefaultCovIncrement() { return defaultCovIncrement; }
+    public void setDefaultCovIncrement(double defaultCovIncrement) { this.defaultCovIncrement = defaultCovIncrement; }
+
+    public boolean isBbmdEnabled() { return bbmdEnabled; }
+    public void setBbmdEnabled(boolean bbmdEnabled) { this.bbmdEnabled = bbmdEnabled; }
+}

--- a/apps/edge-service/src/main/java/org/metrolink/bas/edge/EdgeServiceApplication.java
+++ b/apps/edge-service/src/main/java/org/metrolink/bas/edge/EdgeServiceApplication.java
@@ -12,7 +12,7 @@ import java.util.Map;
 import java.util.ServiceLoader;
 
 @SpringBootApplication
-@EnableConfigurationProperties(SimConnectorProperties.class)
+@EnableConfigurationProperties({SimConnectorProperties.class, BacnetConnectorProperties.class})
 public class EdgeServiceApplication {
 
     public static void main(String[] args) {

--- a/apps/edge-service/src/main/resources/application.yml
+++ b/apps/edge-service/src/main/resources/application.yml
@@ -15,3 +15,9 @@ connectors:
     ai1Start: 22.5   # try a different start temp to prove config works
     ai1Drift: 0.15   # gentler drift
     periodMs: 750    # faster updates
+  bacnet:
+    deviceInstance: 12345
+    apduTimeoutMs: 3000
+    covRenewSec: 120
+    defaultCovIncrement: 0.1
+    bbmdEnabled: false


### PR DESCRIPTION
Adds @ConfigurationProperties("connectors.bacnet") for typed BACnet settings and enables binding.
No runtime wiring; edge-service continues to use the sim connector.

Closes #9