### PR TITLE
feat(edge-service): selectable active connector via config (sim|bacnet), pass typed config

### DIFF
--- a/apps/edge-service/build.gradle
+++ b/apps/edge-service/build.gradle
@@ -17,6 +17,8 @@ dependencies {
     implementation project(':bas-core')
     // For now wire the sim so the app works immediately.
     implementation project(':connector-sim')
+    implementation project(':connector-bacnet')
+
 
     implementation 'org.springframework.boot:spring-boot-starter-web'
     implementation 'org.springframework.boot:spring-boot-starter-actuator'

--- a/apps/edge-service/src/main/java/org/metrolink/bas/edge/BacnetConnectorProperties.java
+++ b/apps/edge-service/src/main/java/org/metrolink/bas/edge/BacnetConnectorProperties.java
@@ -13,18 +13,43 @@ public class BacnetConnectorProperties {
     private boolean bbmdEnabled = false;
 
     // getters/setters
-    public int getDeviceInstance() { return deviceInstance; }
-    public void setDeviceInstance(int deviceInstance) { this.deviceInstance = deviceInstance; }
+    public int getDeviceInstance() {
+        return deviceInstance;
+    }
 
-    public int getApduTimeoutMs() { return apduTimeoutMs; }
-    public void setApduTimeoutMs(int apduTimeoutMs) { this.apduTimeoutMs = apduTimeoutMs; }
+    public void setDeviceInstance(int deviceInstance) {
+        this.deviceInstance = deviceInstance;
+    }
 
-    public int getCovRenewSec() { return covRenewSec; }
-    public void setCovRenewSec(int covRenewSec) { this.covRenewSec = covRenewSec; }
+    public int getApduTimeoutMs() {
+        return apduTimeoutMs;
+    }
 
-    public double getDefaultCovIncrement() { return defaultCovIncrement; }
-    public void setDefaultCovIncrement(double defaultCovIncrement) { this.defaultCovIncrement = defaultCovIncrement; }
+    public void setApduTimeoutMs(int apduTimeoutMs) {
+        this.apduTimeoutMs = apduTimeoutMs;
+    }
 
-    public boolean isBbmdEnabled() { return bbmdEnabled; }
-    public void setBbmdEnabled(boolean bbmdEnabled) { this.bbmdEnabled = bbmdEnabled; }
+    public int getCovRenewSec() {
+        return covRenewSec;
+    }
+
+    public void setCovRenewSec(int covRenewSec) {
+        this.covRenewSec = covRenewSec;
+    }
+
+    public double getDefaultCovIncrement() {
+        return defaultCovIncrement;
+    }
+
+    public void setDefaultCovIncrement(double defaultCovIncrement) {
+        this.defaultCovIncrement = defaultCovIncrement;
+    }
+
+    public boolean isBbmdEnabled() {
+        return bbmdEnabled;
+    }
+
+    public void setBbmdEnabled(boolean bbmdEnabled) {
+        this.bbmdEnabled = bbmdEnabled;
+    }
 }

--- a/apps/edge-service/src/main/java/org/metrolink/bas/edge/ConnectorHealthIndicator.java
+++ b/apps/edge-service/src/main/java/org/metrolink/bas/edge/ConnectorHealthIndicator.java
@@ -7,9 +7,13 @@ import org.springframework.stereotype.Component;
 @Component
 public class ConnectorHealthIndicator implements HealthIndicator {
     private final HealthPort health;
-    public ConnectorHealthIndicator(HealthPort health) { this.health = health; }
 
-    @Override public Health health() {
+    public ConnectorHealthIndicator(HealthPort health) {
+        this.health = health;
+    }
+
+    @Override
+    public Health health() {
         var s = health.health();
         var builder = s.up() ? Health.up() : Health.down();
         if (s.metrics() != null) builder.withDetails(s.metrics());

--- a/apps/edge-service/src/main/java/org/metrolink/bas/edge/ConnectorsSelectionProperties.java
+++ b/apps/edge-service/src/main/java/org/metrolink/bas/edge/ConnectorsSelectionProperties.java
@@ -1,0 +1,19 @@
+package org.metrolink.bas.edge;
+
+import org.springframework.boot.context.properties.ConfigurationProperties;
+
+@ConfigurationProperties(prefix = "connectors")
+public class ConnectorsSelectionProperties {
+    /**
+     * Which connector to use at runtime: "sim" or "bacnet". Default is "sim".
+     */
+    private String active = "sim";
+
+    public String getActive() {
+        return active;
+    }
+
+    public void setActive(String active) {
+        this.active = active;
+    }
+}

--- a/apps/edge-service/src/main/java/org/metrolink/bas/edge/SimConnectorProperties.java
+++ b/apps/edge-service/src/main/java/org/metrolink/bas/edge/SimConnectorProperties.java
@@ -6,13 +6,30 @@ import org.springframework.boot.context.properties.ConfigurationProperties;
 public class SimConnectorProperties {
     private double ai1Start = 21.0; // °C initial
     private double ai1Drift = 0.2;  // per tick drift amplitude
-    private long   periodMs = 1000; // update interval
+    private long periodMs = 1000; // update interval
 
     // getters & setters
-    public double getAi1Start() { return ai1Start; }
-    public void setAi1Start(double v) { this.ai1Start = v; }
-    public double getAi1Drift() { return ai1Drift; }
-    public void setAi1Drift(double v) { this.ai1Drift = v; }
-    public long getPeriodMs() { return periodMs; }
-    public void setPeriodMs(long v) { this.periodMs = v; }
+    public double getAi1Start() {
+        return ai1Start;
+    }
+
+    public void setAi1Start(double v) {
+        this.ai1Start = v;
+    }
+
+    public double getAi1Drift() {
+        return ai1Drift;
+    }
+
+    public void setAi1Drift(double v) {
+        this.ai1Drift = v;
+    }
+
+    public long getPeriodMs() {
+        return periodMs;
+    }
+
+    public void setPeriodMs(long v) {
+        this.periodMs = v;
+    }
 }

--- a/apps/edge-service/src/main/resources/application.yml
+++ b/apps/edge-service/src/main/resources/application.yml
@@ -11,10 +11,11 @@ management:
       application: edge-service
 
 connectors:
+  active: bacnet  # default behavior
   sim:
-    ai1Start: 22.5   # try a different start temp to prove config works
-    ai1Drift: 0.15   # gentler drift
-    periodMs: 750    # faster updates
+    ai1Start: 22.5
+    ai1Drift: 0.15
+    periodMs: 750
   bacnet:
     deviceInstance: 12345
     apduTimeoutMs: 3000


### PR DESCRIPTION
- New @ConfigurationProperties("connectors") with `active` = "sim"|"bacnet"
- EdgeServiceApplication chooses the plugin by id via ServiceLoader
- Builds cfg from the matching typed properties and calls plugin.init(cfg)/start()
- apps/edge-service now depends on both connector-sim and connector-bacnet

Default remains sim. Switching to "bacnet" starts the app; endpoints throw (skeleton), as expected.

Closes #11
